### PR TITLE
Added test coverage reporting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -53,7 +52,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
-
+.coveragerc
 # Translations
 *.mo
 *.pot

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
-.coveragerc
+
 # Translations
 *.mo
 *.pot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,20 @@ Before submitting an issue please make sure:
 
 7. Create a new pull request with an appropriate title, detailed explanation of what the pull request does and attach links to other issues or pull requests related to your pull request
 
+## Running test coverage
+
+Generating a report of lines that do not have test coverage can indicate where to start contributing. Run `pytest` using `coverage` and generate a report.
+
+```bash
+    $ coverage run --source=./preprocessy -m pytest
+
+    $ coverage html
+```
+
+Open `htmlcov/index.html` in your browser to explore the report.
+
+Read more about [coverage](https://coverage.readthedocs.io/en/coverage-5.4/).
+
 ## License
 
 By contributing your code to the Preprocessy GitHub repository, you agree to license your contribution under the [MIT](https://github.com/preprocessy/preprocessy/blob/master/LICENSE) license.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,7 @@ attrs==20.2.0
 black==20.8b1
 click==7.1.2
 codespell==1.17.1
+coverage==5.4
 importlib-metadata==3.1.1
 isort==5.6.4
 lazy-object-proxy


### PR DESCRIPTION
Added `coverage` to generate reports showing code coverage by tests. This will be useful for writing tests that cover as much of the codebase as possible. Closes #39 

Changes made - 

- [x] Updated the `requirements_dev.txt`
- [x] Added usage instructions to `CONTRIBUTING.md`