### PR TITLE
Fixed bugs in encoding

### DIFF
--- a/datasets/encoding/testnew.csv
+++ b/datasets/encoding/testnew.csv
@@ -1,4 +1,4 @@
-Test,Price,Negatives,Profession,Date
-Mahindra,"$12,000",-2,Student,12 Mar 2001
-Tata,"$32,987","-12,000",Teacher,14 Feb 2005
-Honda,$1667,-7,HOD,29 Jun 2016
+Test,Price,Negatives,Profession,Date,Float
+Mahindra,"$12,000",-2,Student,12 Mar 2001,2.3
+Tata,"$32,987","-12,000",Teacher,14 Feb 2005,4.2
+Honda,$1667,-7,HOD,29 Jun 2016,3.6

--- a/preprocessy/encoding/_categorical.py
+++ b/preprocessy/encoding/_categorical.py
@@ -13,6 +13,7 @@ class EncodeData:
 
         self.cat_cols = None
         self.ord_dict = None
+        self.ord_cols = []
         self.one_hot = False
 
     def __repr__(self):
@@ -121,7 +122,7 @@ class EncodeData:
             self.cat_cols = []
             for col in self.train_df.columns:
                 if col not in self.ord_cols:
-                    if (
+                    if self.train_df[col].dtype == "object" and (
                         "$" in self.train_df[col][0]
                         or self.train_df[col].str.contains(",").any()
                     ):
@@ -156,7 +157,6 @@ class EncodeData:
         Function to encode ordinal columns as provided by user in the form of a dictionary. Format for the
         parameter is specified at the top during initialization.
         """
-        self.ord_cols = []
         for key, value in self.ord_dict.items():
             if key in self.train_df.columns:
                 if self.test_df is not None:


### PR DESCRIPTION
Turns out case 2 wasn't a bug after all since column names in the dataframe get updated. Fixes #65 

Changes made - 
- Moved definition of `self.ord_cols` to the constructor
- Fixed a bug in the condition to check the presence of $ in any column value. If a column has a type other than object, the code breaks, therefore the check.