### PR TITLE
Added save config method to base pipeline

### DIFF
--- a/datasets/configs/pipeline_config.json
+++ b/datasets/configs/pipeline_config.json
@@ -1,5 +1,7 @@
 {
   "col_1": "A",
   "col_2": "B",
-  "test_size": 0.2
+  "test_size": 0.2,
+  "train_df_path": "./datasets/configs/dataset.csv",
+  "test_df_path": null
 }

--- a/preprocessy/pipelines/_base.py
+++ b/preprocessy/pipelines/_base.py
@@ -10,6 +10,7 @@ from prettytable import PrettyTable
 from ..exceptions import ArgumentsError
 from ..input import Reader
 from .config import read_config
+from .config import save_config
 
 init()
 
@@ -54,6 +55,14 @@ class BasePipeline:
         self.train_df_path = train_df_path
         self.test_df_path = test_df_path
         self.config_file = config_file
+        self.config_drop_keys = [
+            "train_df",
+            "test_df",
+            "X_train",
+            "X_test",
+            "y_train",
+            "y_test",
+        ]
         self.steps = steps
         self.custom_reader = custom_reader
         self.__validate_input()
@@ -265,6 +274,19 @@ class BasePipeline:
             )
 
         self.steps.remove(func)
+
+    def save_config(self, file_path, config_drop_keys=None):
+        """Method to save the ``params`` to a ``JSON`` config file
+
+        :param file_path: Path where the config file must be created
+        :type file_path: str
+        :param config_drop_keys: List of param keys that must not be stored in the config file,
+                            defaults to ``["train_df", "test_df", "X_train", "X_test", "y_train", "y_test"]``
+        :type config_drop_keys: list, optional
+        """
+        if not config_drop_keys:
+            config_drop_keys = self.config_drop_keys
+        save_config(file_path, self.params, config_drop_keys)
 
     def print_info(self):
         """Prints the current configuration of the pipeline. Shows the steps, dataframe paths and config paths."""

--- a/preprocessy/pipelines/config.py
+++ b/preprocessy/pipelines/config.py
@@ -30,20 +30,24 @@ def read_config(file_path):
     if "train_df_path" in content:
         warnings.warn(
             "The dataset has to be passed as param to the Pipeline class, any"
-            " value provided here will be overridden."
+            " value provided in the config file will be overridden."
         )
     return content
 
 
 # save the params object to a file
-def save_config(file_path, params):
+def save_config(file_path, params, config_drop_keys):
+    if not isinstance(config_drop_keys, list):
+        raise TypeError(
+            f"config_drop_keys should be of type list. Received {config_drop_keys} of type {type(config_drop_keys)}."
+        )
+
     try:
         with open(file_path, "w") as f:
             params_copy = copy.deepcopy(params)
-            if "train_df" in params_copy.keys():
-                params_copy.pop("train_df")
-            if "test_df" in params_copy.keys():
-                params_copy.pop("test_df")
+            for key in config_drop_keys:
+                if key in params_copy.keys():
+                    params_copy.pop(key)
             json.dump(params_copy, f, indent=2)
     except Exception as e:
         print(f"Error occurred while saving config to file : {str(e)}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,6 @@ def test_save():
         "param2": {"nestedParam": 420},
         "Split": 6969,
     }
-    save_config(filepath, params)
+    save_config(filepath, params, [])
     contents = read_config(filepath)
     assert params == contents


### PR DESCRIPTION
`BasePipeline` class did not have a `save_config` method. The `save_config` method takes two arguments 
- `file_path`
- `config_drop_keys` - This is the list of keys that should not be stored in the config file. Keys like the entire pandas data frame, or other big params. There is a default list of keys, which can be overridden by passing this paramenter.