### PR TITLE
Added option to control shuffling of data in train test split

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -52,3 +52,7 @@ Any parameter marked ``*`` are essential to the smooth working of the pipeline a
 - test_size(``float,int``): Size of test set after splitting. Can take values from 0 - 1 for float point values, 0 - Number of samples for integer values. Is complementary to train size.
 
 - train_size(``float,int``): Size of train set after splitting. Can take values from 0 - 1 for float point values, 0 - Number of samples for integer values. Is complementary to test size.
+
+- shuffle(``bool``): Decides whether to shuffle data before splitting.
+
+- random_state(``int``): Seeding to be provided for shuffling before splitting.

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -6,7 +6,12 @@ from preprocessy.resampling import Split
 
 def test_without_target_col():
     df = pd.DataFrame(np.arange(1000).reshape(100, 10))
-    params = {"train_df": df, "test_size": 0.2, "random_state": 420}
+    params = {
+        "train_df": df,
+        "test_size": 0.2,
+        "random_state": 420,
+        "shuffle": True,
+    }
     split = Split()
     split.train_test_split(params=params)
     assert params["X_train"].shape[0] == 80


### PR DESCRIPTION
`train_test_split` by default shuffled the data with a given `random_state`. Added `shuffle` boolean which when `False` won't shuffle the data. `random_state` will be set if one is provided.