### PR TITLE
Fix BasePipeline steps argument

### DIFF
--- a/preprocessy/pipelines/_base.py
+++ b/preprocessy/pipelines/_base.py
@@ -67,6 +67,8 @@ class BasePipeline:
         ]
         if steps is None:
             self.steps = []
+        else:
+            self.steps = steps
         self.custom_reader = custom_reader
         self.__validate_input()
 

--- a/preprocessy/pipelines/_base.py
+++ b/preprocessy/pipelines/_base.py
@@ -46,7 +46,7 @@ class BasePipeline:
         self,
         train_df_path=None,
         test_df_path=None,
-        steps=None,
+        steps=[],
         config_file=None,
         params=None,
         custom_reader=None,
@@ -62,6 +62,8 @@ class BasePipeline:
             "X_test",
             "y_train",
             "y_test",
+            "train_df_path",
+            "test_df_path",
         ]
         self.steps = steps
         self.custom_reader = custom_reader
@@ -97,7 +99,7 @@ class BasePipeline:
                 " either a list of steps or path to a JSON config file."
             )
 
-        if self.steps and not isinstance(self.steps, list):
+        if not isinstance(self.steps, list):
             raise TypeError(
                 f"'steps' should be of type 'list'. Received {self.steps} of"
                 f" type {type(self.steps)}"

--- a/preprocessy/pipelines/_base.py
+++ b/preprocessy/pipelines/_base.py
@@ -46,7 +46,7 @@ class BasePipeline:
         self,
         train_df_path=None,
         test_df_path=None,
-        steps=[],
+        steps=None,
         config_file=None,
         params=None,
         custom_reader=None,
@@ -65,7 +65,8 @@ class BasePipeline:
             "train_df_path",
             "test_df_path",
         ]
-        self.steps = steps
+        if steps is None:
+            self.steps = []
         self.custom_reader = custom_reader
         self.__validate_input()
 


### PR DESCRIPTION
*  ```Steps``` defaults to an empty list now
*  Validation for ```steps``` fixed
*  Added ```train_df_path``` and ```test_df_path``` to ```config_drop_keys``` since df paths are required in the initialization of the pipeline class so it does not make sense to keep them in the config file as well. 
- Fixes #102 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest`, no tests failed.
