### PR TITLE
Updated outlier docs and made replace datatype as bool

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -24,11 +24,11 @@ Any parameter marked ``*`` are essential to the smooth working of the pipeline a
 
 - fill_values(``dict``): Dictionary with keys as column names and values that fill the null records in corresponding column.
 
-- one_hot(``bool``): ``True`` if one hot encoding desired. Default= ``False``.
+- one_hot(``bool``): ``True`` if one hot encoding desired. Default = ``False``.
 
-- remove_outliers(``bool``): ``True`` if outlier records to be removed. Default= ``True``. If ``False`` then ``replace`` parameter must be given.
+- remove_outliers(``bool``): ``True`` if outlier records to be removed. If ``False`` then ``replace`` parameter must be given. Default = ``True``
 
-- replace(``int``): Integer value to replace all outliers with.
+- replace(``bool``): Boolean value to indicate if the outliers need to be replaced by ``-999``. Default = False.
 
 - first_quartile(``float``): Float value less than 1 and represents the first percentile marker. For more see :py:mod:`preprocessy.outliers`
 

--- a/preprocessy/outliers/_handleoutlier.py
+++ b/preprocessy/outliers/_handleoutlier.py
@@ -181,9 +181,9 @@ class HandleOutlier:
         :param ord_cols: List containing the column names to be encoded ordinally.This parameter is needed to ensure that the ordinal columns isn't included in the outlier removing process.
         :type ord_cols: List
 
-        :param replace: Integer value to indicate the value with which to replace the identified outliers.
-                        This will replace and will not remove the outliers
-        :type replace: int
+        :param replace: Boolean value to indicate if the outliers need to be replaced.
+                        This will replace the outliers with ``-999`` and will not remove them.
+        :type replace: bool, default=False
 
         :param first_quartile: Float value <1 representing the first percentile marker
         :type first_quartile: float


### PR DESCRIPTION
Updated the documentation on `replace` param of handling outliers. Changed the datatype to `bool` instead of `int`.

- Fixes #122 
