### PR TITLE
Fixed y_train not inserted in params in tts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 1.0.2
+
+Unreleased
+
+- Train test split should insert ``y_train`` in params when ``target_label`` is provided. :issue:`124`
+
 Version 1.0.1
 -------------
 

--- a/preprocessy/data_splitting/_split.py
+++ b/preprocessy/data_splitting/_split.py
@@ -232,9 +232,10 @@ class Split:
             self.shuffle = params["shuffle"]
         if "random_state" in params.keys():
             self.random_state = params["random_state"]
-        if self.target_label and self.test_df is not None:
+        if self.target_label:
             self.train_y = self.train_df[self.target_label]
-            self.test_y = self.test_df[self.target_label]
+            if self.test_df is not None:
+                self.test_y = self.test_df[self.target_label]
 
         self.__validate_input()
         if self.test_df is not None and self.test_y is not None:


### PR DESCRIPTION
- Fixes #124 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest`, no tests failed.
