### PR TITLE
Dropping redundant target column & Updating version 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
-Version 1.0.3
+Version 1.0.4
 -------------
 
 Unreleased
+
+Version 1.0.3
+-------------
+
+- Train test split should drop target column from ```train_df``` and ```test_df``` so that there is no redundant target column in ```y_train```
 
 Version 1.0.2
 -------------

--- a/preprocessy/data_splitting/_split.py
+++ b/preprocessy/data_splitting/_split.py
@@ -234,8 +234,10 @@ class Split:
             self.random_state = params["random_state"]
         if self.target_label:
             self.train_y = self.train_df[self.target_label]
+            self.train_df = self.train_df.drop([self.target_label], axis=1)
             if self.test_df is not None:
                 self.test_y = self.test_df[self.target_label]
+                self.test_df = self.test_df.drop([self.target_label], axis=1)
 
         self.__validate_input()
         if self.test_df is not None and self.test_y is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "preprocessy"
-version = "1.0.2"
+version = "1.0.3"
 description = "Data Preprocessing library that provides customizable pipelines."
 authors = ["Saif Kazi <saif1204kazi@gmail.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 with io.open("README.md", "rt", encoding="utf8") as f:
     LONG_DESC = f.read()
 
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 
 # This call to setup() does all the work
 setup(


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- Fixes redundancy in target column, affected ```y_train```
- Updating the version of the package to 1.0.3

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest`, no tests failed.
