### PR TITLE
Added original_params field and corresponding getter and setter to BasePipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 1.0.4
 
 Unreleased
 
+- Added ``__original_params`` field and corresponding getter and setter to ``BasePipeline``. :issue:`135`
+
 Version 1.0.3
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Version 1.0.4
 
 Unreleased
 
-- Added ``__original_params`` field and corresponding getter and setter to ``BasePipeline``. :issue:`135`
+- ``params`` field has been renamed to ``__params`` and corresponding getter and setter
+  have been added to ``BasePipeline``. :issue:`135`
 
 Version 1.0.3
 -------------

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -231,6 +231,49 @@ def test_remove():
     assert pipeline.params["train_df"].shape[0] == df.shape[0]
 
 
+def test_get_original_params():
+    df = pd.DataFrame({"A": np.arange(1, 100), "B": np.arange(1, 100)})
+    _ = df.to_csv("./datasets/configs/dataset.csv", index=False)
+    params = {
+        "col_1": "A",
+        "col_2": "B",
+        "test_size": 0.2,
+    }
+    pipeline = BasePipeline(
+        train_df_path="./datasets/configs/dataset.csv",
+        steps=[times_two, squared, split],
+        params=params,
+    )
+    pipeline.process()
+
+    # 3 params + 2 inserted by reader (train_df_path and test_df_path)
+    assert len(pipeline.get_original_params().keys()) == 5
+
+
+def test_set_original_params():
+    df = pd.DataFrame({"A": np.arange(1, 100), "B": np.arange(1, 100)})
+    _ = df.to_csv("./datasets/configs/dataset.csv", index=False)
+    params = {
+        "col_1": "A",
+        "col_2": "B",
+        "test_size": 0.2,
+    }
+    pipeline = BasePipeline(
+        train_df_path="./datasets/configs/dataset.csv",
+        steps=[times_two, squared, split],
+        params=params,
+    )
+    pipeline.process()
+
+    assert len(pipeline.get_original_params().keys()) != len(
+        pipeline.params.keys()
+    )
+    pipeline.set_original_params(params)
+    assert len(pipeline.get_original_params().keys()) == len(
+        pipeline.params.keys()
+    )
+
+
 def test_config():
     df = pd.DataFrame({"A": np.arange(1, 100), "B": np.arange(1, 100)})
     _ = df.to_csv("./datasets/configs/dataset.csv", index=False)


### PR DESCRIPTION
Added a new field to the `BasePipeline` class for storing the original parameter dictionary that was passed while creating the pipeline. 

Changes -

- Added getter and setter for `__original_params`
- Setting using the setter overwrites `params`
- `pipeline.add()` now merges the added function's parameters with both `params` and `__original_params`

- Fixes #135 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest`, no tests failed.
