### PR TITLE
Fixed bug in HandleOutliers that replaced outliers in all columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Unreleased
 
 - ``params`` field has been renamed to ``__params`` and corresponding getter and setter
   have been added to ``BasePipeline``. :issue:`135`
+- Fixed bug in outliers that replaced outliers from all columns instead of just numeric
+  columns. :issue:`144`
 
 Version 1.0.3
 -------------

--- a/preprocessy/outliers/_handleoutlier.py
+++ b/preprocessy/outliers/_handleoutlier.py
@@ -49,8 +49,6 @@ class HandleOutlier:
 
         if self.train_df is None:
             raise ValueError("Train dataframe should not be of None type")
-        # not adding validation for whether test_df is included or not since
-        # user choice
 
         if not isinstance(self.train_df, pd.core.frame.DataFrame):
             raise TypeError(
@@ -244,6 +242,7 @@ class HandleOutlier:
                     if self.test_df is not None:
                         self.test_df = self.test_df[(self.test_df[col] > q1)]
                         self.test_df = self.test_df[(self.test_df[col] <= q3)]
+
         # if removeoutliers = False and replace=True i.e. user wants outliers
         # replaced by a value to indicate these are outliers
         elif self.replace:
@@ -252,11 +251,11 @@ class HandleOutlier:
                     self.__return_quartiles(col)
                 for col in self.cols:
                     q1, q3 = self.quartiles[col]
-                    self.train_df[(self.train_df[col] < q1)] = -999
-                    self.train_df[(self.train_df[col] > q3)] = -999
+                    self.train_df[col][(self.train_df[col] < q1)] = -999
+                    self.train_df[col][(self.train_df[col] > q3)] = -999
                     if self.test_df is not None:
-                        self.test_df[(self.test_df[col] <= q1)] = -999
-                        self.test_df[(self.test_df[col] >= q3)] = -999
+                        self.test_df[col][(self.test_df[col] <= q1)] = -999
+                        self.test_df[col][(self.test_df[col] >= q3)] = -999
 
         params["train_df"] = self.train_df
         params["test_df"] = self.test_df

--- a/tests/test_outlier.py
+++ b/tests/test_outlier.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 from preprocessy.exceptions import ArgumentsError
@@ -158,3 +159,25 @@ def test_all(test_input):
     assert -999 in test_input["train_df"]["Distance"].values
     assert -999 in test_input["test_df"]["Distance"].values
     assert test_input["train_df"].equals(test_input["test_df"])
+
+
+def test_outlier_replace_only_in_numeric_columns():
+    a = np.random.rand(
+        100,
+    )
+    a[95:] = 1504360
+    b = [0 if i % 2 == 0 else 1 for i in range(100)]
+    b = np.asarray(b)
+    b[70:] = 42
+    data = {"A": a, "B": b}
+    sample_df = pd.DataFrame(data)
+    params = {
+        "train_df": sample_df,
+        "cat_cols": ["B"],
+        "remove_outliers": False,
+        "replace": True,
+    }
+    outlier = HandleOutlier()
+    outlier.handle_outliers(params=params)
+    assert -999 in params["train_df"]["A"].values[95:]
+    assert (params["train_df"]["B"].compare(sample_df["B"])).empty


### PR DESCRIPTION
Replacing outliers will now replace outliers from only numeric columns with default value of `-999`.

- Fixes #144 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest`, no tests failed.
