### PR TITLE
Fixed dataframe and target variable shape validation bug in train test split

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
   have been added to ``BasePipeline``. :issue:`135`
 - Fixed bug in outliers that replaced outliers from all columns instead of just numeric
   columns. :issue:`144`
+- Fixed bug in ``train_test_split`` that tried to access ``train_df`` and ``train_y`` by their old
+  variable names. :issue:`147`
 
 Version 1.0.3
 -------------

--- a/preprocessy/data_splitting/_split.py
+++ b/preprocessy/data_splitting/_split.py
@@ -75,7 +75,7 @@ class Split:
                 raise ValueError(
                     "Number of samples of target label and feature dataframe"
                     " unequal.\nSamples in feature dataframe:"
-                    f" {self.X.shape[0]}\nSamples in target label: {self.y.shape[0]}"
+                    f" {self.train_df.shape[0]}\nSamples in target label: {self.train_y.shape[0]}"
                 )
             if not isinstance(self.train_y, pd.core.series.Series):
                 raise TypeError(


### PR DESCRIPTION
- Fixes #147 

Checklist:

- [x] Add tests that demonstrate the correct behaviour of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest`, no tests failed.
